### PR TITLE
use LazyData: true

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,7 @@ Depends: R (>= 3.5.0)
 Imports: R6, stats, ape, vegan, rlang, data.table, magrittr, dplyr, tibble, scales, grid, ggplot2, RColorBrewer, reshape2
 Suggests: GUniFrac, MASS, ggpubr, randomForest, ggdendro, ggrepel, agricolae, gridExtra, picante, pheatmap, igraph, rgexf, tidytree, mice, ggtree
 License: GPL-3
+LazyData: true
 Encoding: UTF-8
 NeedsCompilation: no
 Packaged: 2021-11-16


### PR DESCRIPTION
As part of testing reverse dependencies of dplyr, before its imminent release, we've identified the following potential problem with this package: 

````
# microeco

<details>

* Version: 0.6.0
* GitHub: NA
* Source code: https://github.com/cran/microeco
* Date/Publication: 2021-11-16 09:10:02 UTC
* Number of recursive dependencies: 190

Run `cloud_details(, "microeco")` for more info

</details>

## Newly broken

*   checking contents of ‘data’ directory ... WARNING
    ```
    Output for data("dataset", package = "microeco"):
      Search path was changed
    ```

## In both

*   checking package dependencies ... NOTE
    ```
    Package suggested but not available for checking: ‘ggtree’
    ```

*   checking dependencies in R code ... NOTE
    ```
    Namespace in Imports field not imported from: ‘reshape2’
      All declared Imports should be used.
    ```
````

using `LazyData` is one way to fix it. 